### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/src/athena/core/permissions.py
+++ b/src/athena/core/permissions.py
@@ -450,7 +450,8 @@ class PermissionEngine:
         if len(self.audit_log) > 1000:
             self.audit_log = self.audit_log[-500:]
 
-        logger.debug(f"Permission {action}: {target} → {details}")
+        redacted_details = self.redact(json.dumps(details, default=str))
+        logger.debug(f"Permission {action}: {target} → {redacted_details}")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Potential fix for [https://github.com/winstonkoh87/Athena-Public/security/code-scanning/5](https://github.com/winstonkoh87/Athena-Public/security/code-scanning/5)

In general, the fix is to avoid logging raw `details` dictionaries that can contain sensitive or secret-related fields. Instead, the code should either (1) omit such fields from logs, or (2) pass all values through an existing redaction routine before logging. Since `PermissionEngine` already has a `redact` method that is meant to scrub secret patterns from content, the most direct fix without changing functionality is to apply `redact` to the string we log, or to construct a redacted copy of `details` for logging only.

The best minimal change here is to keep internal state and returned values untouched, but change `_audit` so that it does not log `details` in clear text. We can do this by serializing `details` to JSON and passing that string through `self.redact` (or, to keep `_audit` static and independent, by moving logging into an instance method—but that would be a bigger refactor). Since `_audit` is currently an instance method (uses `self.audit_log`), it can call `self.redact`. A concrete change in `src/athena/core/permissions.py` around lines 439–454: compute a `redacted_details` string such as `self.redact(json.dumps(details, default=str))` and use that in the log message, instead of interpolating `details` directly. This reuses existing imports (`json` is already imported at line 24) and existing redaction logic, and preserves the structure of `_audit` and the rest of the engine.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
